### PR TITLE
Fix organization repository URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This repository contains files that are global to the organization (e.g. `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, etc.). They are the defaults in all repositories under `ietf-tools`, unless a local one is present.
+https://github.com/ietf-tools/.github.gitThis repository contains files that are global to the organization (e.g. `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, etc.). They are the defaults in all repositories under `ietf-tools`, unless a local one is present.


### PR DESCRIPTION
Corrected the URL format for the organization repository in the README.